### PR TITLE
feat: 支持多种时间格式

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
+FROM golang:1.18 as builder
+
+ADD . /go/src/kubefree
+
+WORKDIR /go/src/kubefree/cmd/kubefree-controller
+
+RUN go install . && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build . 
+
+
 FROM ubuntu:18.04
 
-ADD kubefree /kubefree
-ENTRYPOINT ["./kubefree"]
+COPY --from=builder /go/src/kubefree/cmd/kubefree-controller/kubefree-controller /kubefree
 
+ENTRYPOINT ["./kubefree"]

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -194,7 +194,7 @@ func (c *controller) checkNamespace(ns *v1.Namespace) error {
 
 	lastActivityStatus, err := getActivity(ac)
 	if err != nil {
-		logrus.WithError(err).Fatalln("Error getActivity")
+		logrus.WithError(err).Fatalln("Error getActivity: %v", ac)
 		return err
 	}
 
@@ -230,7 +230,7 @@ func (c *controller) syncSleepAfterRules(namespace *v1.Namespace, lastActivity a
 	}
 
 	state := namespace.Labels[c.ExecutionStateSelector]
-	if time.Since(lastActivity.LastActivityTime) > thresholdDuration {
+	if time.Since(lastActivity.LastActivityTime.Time()) > thresholdDuration {
 		switch state {
 		case DELETING:
 			// do nothing
@@ -244,7 +244,7 @@ func (c *controller) syncSleepAfterRules(namespace *v1.Namespace, lastActivity a
 			}
 			// delete namespace if the namespace still in inactivity status
 			// after thresholdDuration * 2 time
-			if namespace.Status.Phase != v1.NamespaceTerminating && time.Since(lastActivity.LastActivityTime) > thresholdDuration*2 {
+			if namespace.Status.Phase != v1.NamespaceTerminating && time.Since(lastActivity.LastActivityTime.Time()) > thresholdDuration*2 {
 				logrus.WithField("namespace", namespace.Name).
 					WithField("lastActivityTime", lastActivity.LastActivityTime).
 					WithField("sleep-after", v).Info("delete inactivity namespace")
@@ -313,6 +313,7 @@ func (c *controller) syncDeleteAfterRules(namespace *v1.Namespace, lastActivity 
 	}
 
 	if time.Since(lastActivity.LastActivityTime) > thresholdDuration && namespace.Status.Phase != v1.NamespaceTerminating {
+		// Delete the namespace
 		logrus.WithField("namespace", namespace.Name).
 			WithField("lastActivityTime", lastActivity.LastActivityTime).
 			WithField("delete-after", v).Info("deleting inactivity namespace")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -154,7 +154,9 @@ func (c *controller) processItem(key string) error {
 
 	if err := c.checkNamespace(obj.(*v1.Namespace)); err != nil {
 		logrus.WithError(err).Infof("checkNamespace failed, ns: %s", key)
-		return err
+
+	    // Do not handle when namespace check fails, instead of exiting the program
+		return nil
 	}
 
 	return nil
@@ -194,7 +196,7 @@ func (c *controller) checkNamespace(ns *v1.Namespace) error {
 
 	lastActivityStatus, err := getActivity(ac)
 	if err != nil {
-		logrus.WithError(err).Fatalln("Error getActivity: %v", ac)
+		logrus.WithError(err).Errorln("Error getActivity: %v", ac)
 		return err
 	}
 
@@ -202,13 +204,13 @@ func (c *controller) checkNamespace(ns *v1.Namespace) error {
 
 	// check delete-after-seconds rules
 	if err = c.syncDeleteAfterRules(ns, *lastActivityStatus); err != nil {
-		logrus.WithError(err).Fatalln("Error SyncDeleteAfterRules")
+		logrus.WithError(err).Errorln("Error SyncDeleteAfterRules")
 		return err
 	}
 
 	// check sleep-after rules
 	if err = c.syncSleepAfterRules(ns, *lastActivityStatus); err != nil {
-		logrus.WithError(err).Fatalln("Error SyncSleepAfterRules")
+		logrus.WithError(err).Errorln("Error SyncSleepAfterRules")
 		return err
 	}
 
@@ -218,7 +220,7 @@ func (c *controller) checkNamespace(ns *v1.Namespace) error {
 // target sleep-after rules
 func (c *controller) syncSleepAfterRules(namespace *v1.Namespace, lastActivity activity) error {
 	v, ok := namespace.Labels[c.SleepAfterSelector]
-	if !ok || v == "" {
+	if !ok || v == ""{
 		// namespace doesn't have sleep-after label, do nothing
 		return nil
 	}
@@ -312,7 +314,7 @@ func (c *controller) syncDeleteAfterRules(namespace *v1.Namespace, lastActivity 
 		return fmt.Errorf("time.ParseDuration failed, label %s, value %s", c.DeleteAfterSelector, v)
 	}
 
-	if time.Since(lastActivity.LastActivityTime) > thresholdDuration && namespace.Status.Phase != v1.NamespaceTerminating {
+	if time.Since(lastActivity.LastActivityTime.Time()) > thresholdDuration && namespace.Status.Phase != v1.NamespaceTerminating {
 		// Delete the namespace
 		logrus.WithField("namespace", namespace.Name).
 			WithField("lastActivityTime", lastActivity.LastActivityTime).


### PR DESCRIPTION
1. 支持两种时间格式："2006-01-02T15:04:05Z07:00" "2006-01-02T15:04:05"
2. 某个namespace解析失败后不影响其它ns继续执行（kubefree不能挂）
3. 支持docker build -t kubefree . 直接编译镜像